### PR TITLE
CHRISM-2017010501: add a TILT_ENVIRONMENT check

### DIFF
--- a/app_context/app_context.go
+++ b/app_context/app_context.go
@@ -34,6 +34,7 @@ type AppContext interface {
 	SetLogger(logger.CtxLogger) AppContext
 	StartStatsSender() error
 	StopStatsSender() error
+	TiltEnv() string
 }
 
 type baseAppContext struct {

--- a/app_context/app_context.go
+++ b/app_context/app_context.go
@@ -55,6 +55,7 @@ type baseAppContext struct {
 	statsSignalChan    chan bool
 	statsDoneChan      chan bool
 	statsRunning       bool
+	tiltEnv            string
 }
 
 func (self *baseAppContext) AppName() string {
@@ -111,6 +112,10 @@ func (self *baseAppContext) RollbarEnabled() bool {
 
 func (self *baseAppContext) ServicePort() int {
 	return self.servicePort
+}
+
+func (self *baseAppContext) TiltEnv() string {
+	return self.tiltEnv
 }
 
 func (self *baseAppContext) SetLogger(logger logger.CtxLogger) AppContext {
@@ -338,6 +343,18 @@ func NewAppContext(app_name string) (AppContext, error) {
 		metricsClient:   metrics.NewNOOPClient(),
 		statsDoneChan:   make(chan bool),
 		statsSignalChan: make(chan bool),
+	}
+
+	appctx.tiltEnv = os.Getenv("TILT_ENVIRONMENT")
+	if appctx.tiltEnv == "" {
+		appctx.tiltEnv = "development"
+	}
+
+	if appctx.tiltEnv != "development" &&
+		appctx.tiltEnv != "testing" &&
+		appctx.tiltEnv != "staging" &&
+		appctx.tiltEnv != "production" {
+		return nil, fmt.Errorf("Unknown TILT_ENVIRONMENT: %s", appctx.tiltEnv)
 	}
 
 	s3loc := os.Getenv("APPCTX_S3_CONFIG")

--- a/app_context/basic_test.go
+++ b/app_context/basic_test.go
@@ -32,6 +32,8 @@ func TestTiltEnv(t *testing.T) {
 	if err == nil {
 		t.Error("app context should have failed")
 	}
+
+	os.Unsetenv("TILT_ENVIRONMENT")
 }
 
 func TestCodeVersion(t *testing.T) {

--- a/app_context/basic_test.go
+++ b/app_context/basic_test.go
@@ -6,6 +6,34 @@ import (
 	"testing"
 )
 
+func TestTiltEnv(t *testing.T) {
+	os.Unsetenv("TILT_ENVIRONMENT")
+	app_ctx, err := NewAppContext("basic_test")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if tiltEnv := app_ctx.TiltEnv(); tiltEnv != "development" {
+		t.Errorf("environment is not development: %s", tiltEnv)
+	}
+
+	os.Setenv("TILT_ENVIRONMENT", "testing")
+
+	app_ctx, err = NewAppContext("basic_test")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if tiltEnv := app_ctx.TiltEnv(); tiltEnv != "testing" {
+		t.Errorf("environment is not testing: %s", tiltEnv)
+	}
+
+	os.Setenv("TILT_ENVIRONMENT", "derp")
+
+	app_ctx, err = NewAppContext("basic_test")
+	if err == nil {
+		t.Error("app context should have failed")
+	}
+}
+
 func TestCodeVersion(t *testing.T) {
 	os.Unsetenv("CODE_VERSION")
 	app_ctx, err := NewAppContext("basic_test")


### PR DESCRIPTION
We use `DANCER_ENVIRONMENT` all over the place in dancer/perl scripts.  This makes a new environment that we can start setting in any context (language agnostic).  That is, if `TILT_ENVIRONMENT` is set, any language or framework should be able to check it and know the environment.